### PR TITLE
fix TS2612 error

### DIFF
--- a/src/pattern.ts
+++ b/src/pattern.ts
@@ -108,7 +108,7 @@ export abstract class Pattern {
 }
 
 export abstract class ChildPattern extends Pattern {
-  public children: undefined;
+  public children: undefined = undefined;
 
   constructor(public name: string | null, public value: Value = null) {
     super();


### PR DESCRIPTION
```console
$ docker run --rm -it hayd/ubuntu-deno run -A https://deno.land/x/docopt@v1.0.6/examples/navalFate.ts
...
Check https://deno.land/x/docopt@v1.0.6/examples/navalFate.ts
error: TS2612 [ERROR]: Property 'children' will overwrite the base property in 'Pattern'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.
  public children: undefined;
         ~~~~~~~~
    at https://deno.land/x/docopt@v1.0.6/src/pattern.ts:111:10
```